### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,4 +1,6 @@
 name: scan
+permissions:
+  contents: read
 
 on:
   workflow_run:


### PR DESCRIPTION
Potential fix for [https://github.com/jim60105/backup-dl/security/code-scanning/2](https://github.com/jim60105/backup-dl/security/code-scanning/2)

To fix the issue, the workflow file should specify a `permissions` block at either the workflow or job level to restrict the permissions available to GITHUB_TOKEN. According to GitHub’s recommendations, if the only actions required are checking out code and uploading artifacts, the recommended minimum is `contents: read`. This should be added at the highest relevant scope (either globally, or within the specific job if jobs have different permission needs). In this case, as there is a single job and no indicated need for elevated privileges, it's best to add `permissions: contents: read` at the root level (just beneath the workflow name).

**Required changes:**
- Edit .github/workflows/scan.yml.
- Insert a `permissions:` block after the `name:` field and before the `on:` field.
- The block should be:
  ```yaml
  permissions:
    contents: read
  ```
No extra methods or imports are needed. Functionality will remain unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
