### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -1,4 +1,6 @@
 name: docker_publish 
+permissions:
+  contents: read
 
 # Controls when the action will run. 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/jim60105/backup-dl/security/code-scanning/1](https://github.com/jim60105/backup-dl/security/code-scanning/1)

To fix this problem, you should add a `permissions` block explicitly specifying the minimal required permissions for the workflow. Since the job’s actions do not need to write or modify repository contents or other resources, start by specifying `contents: read` at the workflow level (top-level, which covers all jobs unless overridden). This will ensure that the default inherited permissions are overridden to enforce read-only access to repository content for the GITHUB_TOKEN, adhering to the principle of least privilege.

You should add the following block after the workflow’s `name:` (i.e., before the `on:` key for clarity and convention):

```yaml
permissions:
  contents: read
```

No new methods, imports, or definitions are needed; this change is purely declarative within the YAML workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
